### PR TITLE
CMS Guide Alterations

### DIFF
--- a/integration-capabilities/discord-role-sync/getting-started.md
+++ b/integration-capabilities/discord-role-sync/getting-started.md
@@ -9,6 +9,11 @@ description: Get started with Sonoran's CMS, CAD, and Discord role sync!
 ## Setup
 
 {% hint style="warning" %}
+This system utilizes API endpoints that require the **Standard** version of Sonoran CMS or higher. For more information, view our [pricing ](../../../../pricing/pricing-faq/)page.\
+\
+{% endhint %}
+
+{% hint style="warning" %}
 Setting up the bot requires you to have the "Manage Server" permissions on the Discord server for security reasons. You must also have access to your server's [API Key information](../../developer-api-documentation/api-integration/getting-started/retrieving-your-credentials.md).
 {% endhint %}
 

--- a/integration-capabilities/in-game-integration-resources/gta-rp-integrations/available-resources/ace-permission-sync.md
+++ b/integration-capabilities/in-game-integration-resources/gta-rp-integrations/available-resources/ace-permission-sync.md
@@ -5,7 +5,7 @@ description: Manage in-game player permissions right from the CMS!
 # Ace Permission Sync
 
 {% hint style="warning" %}
-This resource utilizes API endpoints that require the **standard** version of Sonoran CMS or higher. For more information, view our [pricing ](broken-reference)page.\
+This resource utilizes API endpoints that require the **standard** version of Sonoran CMS or higher. For more information, view our [pricing ](../../../../pricing/pricing-faq/)page.\
 \
 You must have the **Plus** version of Sonoran CMS or higher to utilize the push event functionality for live in-game syncing.
 {% endhint %}


### PR DESCRIPTION
Fixed a link issue on Ace Permission Sync to the Pricing FAQ page.

Added a warning onto the guides for the Discord Bot that it requires the Standard version of CMS or higher to be used.